### PR TITLE
performance improvements generating / writing chunk bytes

### DIFF
--- a/v2/png.go
+++ b/v2/png.go
@@ -252,24 +252,11 @@ func (c *Chunk) Bytes() ([]byte, error) {
 	preallocated := make([]byte, 0, 4+4+c.Length+4)
 	b := bytes.NewBuffer(preallocated)
 
-	err := binary.Write(b, binary.BigEndian, c.Length)
-	if err != nil {
-		return nil, err
-	}
-
-	if _, err := b.Write([]byte(c.Type)); err != nil {
-		return nil, err
-	}
-
-	if c.Data != nil {
-		if _, err := b.Write(c.Data); err != nil {
-			return nil, err
-		}
-	}
-
-	if err := binary.Write(b, binary.BigEndian, c.Crc); err != nil {
-		return nil, err
-	}
+	// Writes to buffer never return an error.
+	_ = binary.Write(b, binary.BigEndian, c.Length)
+	_, _ = b.WriteString(c.Type)
+	_, _ = b.Write(c.Data)
+	_ = binary.Write(b, binary.BigEndian, c.Crc)
 
 	return b.Bytes(), nil
 }
@@ -284,7 +271,7 @@ func (c *Chunk) WriteTo(w io.Writer) (int, error) {
 		return 0, err
 	}
 
-	if _, err := w.Write([]byte(c.Type)); err != nil {
+	if _, err := io.WriteString(w, c.Type); err != nil {
 		return 0, err
 	}
 

--- a/v2/png.go
+++ b/v2/png.go
@@ -248,17 +248,12 @@ func (c *Chunk) Bytes() ([]byte, error) {
 	if len(c.Data) != int(c.Length) {
 		return nil, errors.New("length of data not correct")
 	}
-
-	preallocated := make([]byte, 0, 4+4+c.Length+4)
-	b := bytes.NewBuffer(preallocated)
-
-	// Writes to buffer never return an error.
-	_ = binary.Write(b, binary.BigEndian, c.Length)
-	_, _ = b.WriteString(c.Type)
-	_, _ = b.Write(c.Data)
-	_ = binary.Write(b, binary.BigEndian, c.Crc)
-
-	return b.Bytes(), nil
+	b := make([]byte, 0, 4+4+c.Length+4)
+	b = binary.BigEndian.AppendUint32(b, c.Length)
+	b = append(b, c.Type...)
+	b = append(b, c.Data...)
+	b = binary.BigEndian.AppendUint32(b, c.Crc)
+	return b, nil
 }
 
 // Write encodes and writes the bytes for this chunk.
@@ -267,23 +262,37 @@ func (c *Chunk) WriteTo(w io.Writer) (int, error) {
 		return 0, errors.New("length of data not correct")
 	}
 
-	if err := binary.Write(w, binary.BigEndian, c.Length); err != nil {
-		return 0, err
+	var n int
+
+	b := make([]byte, 4) // uint32 buf
+
+	binary.BigEndian.PutUint32(b, c.Length)
+	if nn, err := w.Write(b); err != nil {
+		return n + nn, err
 	}
 
-	if _, err := io.WriteString(w, c.Type); err != nil {
-		return 0, err
+	n += len(b)
+
+	if nn, err := io.WriteString(w, c.Type); err != nil {
+		return n + nn, err
 	}
 
-	if _, err := w.Write(c.Data); err != nil {
-		return 0, err
+	n += len(c.Type)
+
+	if nn, err := w.Write(c.Data); err != nil {
+		return n + nn, err
 	}
 
-	if err := binary.Write(w, binary.BigEndian, c.Crc); err != nil {
-		return 0, err
+	n += len(c.Data)
+
+	binary.BigEndian.PutUint32(b, c.Crc)
+	if nn, err := w.Write(b); err != nil {
+		return n + nn, err
 	}
 
-	return 4 + len(c.Type) + len(c.Data) + 4, nil
+	n += len(b)
+
+	return n, nil
 }
 
 // readHeader verifies that the PNG header bytes appear next.


### PR DESCRIPTION
Reduces allocations during v2/png.go Chunk{}.Bytes() and Chunk{}.WriteTo() by using string writer methods where possible, and reduces complexity by reducing need for byte buffers and just using byte slices with binary.BigEndian.{Put,Append}Uint32()